### PR TITLE
fix terms of use checking

### DIFF
--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -360,7 +360,7 @@ class _SuperstaQClient:
 
     def _handle_status_codes(self, response: requests.Response) -> None:
         if response.status_code == requests.codes.unauthorized:
-            if response.text == (
+            if response.json() == (
                 "You must accept the Terms of Use (superstaq.super.tech/terms_of_use)."
             ):
                 self._prompt_accept_terms_of_use()

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -124,7 +124,9 @@ def test_superstaq_client_needs_accept_terms_of_use(
     fake_get_response = mock.MagicMock()
     fake_get_response.ok = False
     fake_get_response.status_code = requests.codes.unauthorized
-    fake_get_response.text = "You must accept the Terms of Use (superstaq.super.tech/terms_of_use)."
+    fake_get_response.json.return_value = (
+        "You must accept the Terms of Use (superstaq.super.tech/terms_of_use)."
+    )
     mock_get.return_value = fake_get_response
 
     mock_accept_terms_of_use.return_value = "YES response required to proceed"


### PR DESCRIPTION
previously [this check](https://github.com/SupertechLabs/client-superstaq/blob/main/general-superstaq/general_superstaq/superstaq_client.py#L363-L365) didn't catch anything, because `response.text` always contains the json-serialized response string, e.g.
```python
'"You must accept the Terms of Use (superstaq.super.tech/terms_of_use)."\n'
```
instead of just
```python
"You must accept the Terms of Use (superstaq.super.tech/terms_of_use)."
```
Calling `response.json()` instead deserializes the response content, and so returns the correct string for comparison


confirmed locally that after this change the message handling works as expected:
![screenshot](https://user-images.githubusercontent.com/85512171/227030661-08835a2c-e0a7-4d10-a5b0-d6e75b4871d5.png)