### PR TITLE
pin symengine<0.10.0

### DIFF
--- a/cirq-superstaq/cirq_superstaq/compiler_output.py
+++ b/cirq-superstaq/cirq_superstaq/compiler_output.py
@@ -131,12 +131,12 @@ def read_json_ibmq(json_dict: Dict[str, Any], circuits_is_list: bool) -> Compile
             pulses = gss.serialization.deserialize(json_dict["pulses"])
         else:
             warnings.warn(
-                "ibmq_compile requires Qiskit Terra version 0.20.* to deserialize compiled pulse "
+                "ibmq_compile requires Qiskit Terra version 0.22.* to deserialize compiled pulse "
                 f"sequences (you have {qiskit.__version__})."
             )
     else:
         warnings.warn(
-            "ibmq_compile requires Qiskit Terra version 0.20.* to deserialize compiled pulse "
+            "ibmq_compile requires Qiskit Terra version 0.22.* to deserialize compiled pulse "
             "sequences."
         )
 

--- a/cirq-superstaq/dev-requirements.txt
+++ b/cirq-superstaq/dev-requirements.txt
@@ -1,2 +1,3 @@
 general-superstaq[dev]~=0.3.22
 qiskit-terra~=0.22.0
+symengine<0.10.0  # see https://github.com/Qiskit/qiskit-terra/pull/9857

--- a/cirq-superstaq/example-requirements.txt
+++ b/cirq-superstaq/example-requirements.txt
@@ -1,2 +1,3 @@
 notebook~=6.4.12
 qiskit-terra~=0.22.0
+symengine<0.10.0  # see https://github.com/Qiskit/qiskit-terra/pull/9857

--- a/cirq-superstaq/examples/ibmq_compile.ipynb
+++ b/cirq-superstaq/examples/ibmq_compile.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "if install_qiskit:\n",
     "    print(\"installing qiskit...\")\n",
-    "    !pip install -q qiskit-terra==0.22.*\n",
+    "    !pip install -q cirq-superstaq[examples]\n",
     "    print(\"installed qiskit.\")"
    ]
   },

--- a/cirq-superstaq/examples/resource_estimate.ipynb
+++ b/cirq-superstaq/examples/resource_estimate.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "if install_qiskit:\n",
     "    print(\"installing qiskit...\")\n",
-    "    !pip install -q qiskit-terra==0.22.*\n",
+    "    !pip install -q cirq-superstaq[examples]\n",
     "    print(\"installed qiskit.\")"
    ]
   },

--- a/qiskit-superstaq/requirements.txt
+++ b/qiskit-superstaq/requirements.txt
@@ -2,3 +2,4 @@ general-superstaq~=0.3.22
 matplotlib~=3.0
 qiskit>=0.37.0
 qiskit-terra==0.22.*
+symengine<0.10.0  # see https://github.com/Qiskit/qiskit-terra/pull/9857


### PR DESCRIPTION
the new version was released today and has been causing our notebook tests to fail (see also https://github.com/Qiskit/qiskit-terra/pull/9857)