### PR TITLE
mock environ in `test_find_api_key` so it passes when SUPERSTAQ_API_KEY is set locally

### DIFF
--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -783,12 +783,13 @@ def test_find_api_key() -> None:
         assert gss.superstaq_client.find_api_key() == "tomyheart"
 
     # find key in a config file
-    with mock.patch("pathlib.Path.is_file", return_value=True):
-        with mock.patch("builtins.open", mock.mock_open(read_data="tomyheart")):
-            assert gss.superstaq_client.find_api_key() == "tomyheart"
+    with mock.patch.dict(os.environ, clear=True):
+        with mock.patch("pathlib.Path.is_file", return_value=True):
+            with mock.patch("builtins.open", mock.mock_open(read_data="tomyheart")):
+                assert gss.superstaq_client.find_api_key() == "tomyheart"
 
     # fail to find an API key :(
     with pytest.raises(EnvironmentError, match="SuperstaQ API key not specified and not found."):
-        with mock.patch.dict(os.environ, {}):
+        with mock.patch.dict(os.environ, clear=True):
             with mock.patch("pathlib.Path.is_file", return_value=False):
                 gss.superstaq_client.find_api_key()

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -783,13 +783,13 @@ def test_find_api_key() -> None:
         assert gss.superstaq_client.find_api_key() == "tomyheart"
 
     # find key in a config file
-    with mock.patch.dict(os.environ, clear=True):
+    with mock.patch.dict(os.environ, SUPERSTAQ_API_KEY=""):
         with mock.patch("pathlib.Path.is_file", return_value=True):
             with mock.patch("builtins.open", mock.mock_open(read_data="tomyheart")):
                 assert gss.superstaq_client.find_api_key() == "tomyheart"
 
     # fail to find an API key :(
     with pytest.raises(EnvironmentError, match="SuperstaQ API key not specified and not found."):
-        with mock.patch.dict(os.environ, clear=True):
+        with mock.patch.dict(os.environ, SUPERSTAQ_API_KEY=""):
             with mock.patch("pathlib.Path.is_file", return_value=False):
                 gss.superstaq_client.find_api_key()


### PR DESCRIPTION
previously the part of the test which was supposed to read the key from a file would fail because the env variable took precedence