### PR TITLE
Removes use of deprecated qubit index access

### DIFF
--- a/supermarq-benchmarks/supermarq/converters.py
+++ b/supermarq-benchmarks/supermarq/converters.py
@@ -35,7 +35,7 @@ def compute_communication_with_qiskit(circuit: qiskit.circuit.QuantumCircuit) ->
     graph = nx.Graph()
     for op in dag.two_qubit_ops():
         q1, q2 = op.qargs
-        graph.add_edge(q1.index, q2.index)
+        graph.add_edge(circuit.find_bit(q1).index, circuit.find_bit(q2).index)
 
     degree_sum = sum([graph.degree(n) for n in graph.nodes])
 
@@ -63,7 +63,7 @@ def compute_liveness_with_qiskit(circuit: qiskit.circuit.QuantumCircuit) -> floa
     for i, layer in enumerate(dag.layers()):
         for op in layer["partition"]:
             for qubit in op:
-                activity_matrix[qubit.index, i] = 1
+                activity_matrix[circuit.find_bit(qubit).index, i] = 1
 
     return np.sum(activity_matrix) / (num_qubits * dag.depth())
 


### PR DESCRIPTION
Fixes #407. Results in warning-free output, compare with #407:
```
...
supermarq-benchmarks/supermarq/benchmarks/mermin_bell_test.py ..                               [ 87%]
supermarq-benchmarks/supermarq/benchmarks/phase_code_test.py ...                               [ 96%]
supermarq-benchmarks/supermarq/converters_test.py .                                            [100%]

======================================== 31 passed in 36.14s =========================================
Name    Stmts   Miss    Cover   Missing
---------------------------------------
TOTAL    1007      0  100.00%
...
```