### PR TITLE
don't ignore relative phase of sub_gate in `QubitSubspaceGate`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
@@ -422,11 +422,9 @@ class QubitSubspaceGate(cirq.Gate):  # pylint: disable=missing-class-docstring
         if other.subspaces != self.subspaces:
             return False
 
-        return cirq.equal_up_to_global_phase(
-            self.sub_gate, other.sub_gate, atol=atol
-        ) or cirq.equal_up_to_global_phase(
-            other.sub_gate, self.sub_gate, atol=atol
-        )  # Test both orders as a workaround for https://github.com/quantumlib/Cirq/issues/5980
+        # Do not ignore global phase when comparing sub gates, as it becomes physical when the gate
+        # is expanded to higher dimensions
+        return cirq.approx_eq(self.sub_gate, other.sub_gate, atol=atol)
 
     def _json_dict_(self) -> Dict[str, Any]:
         return cirq.obj_to_dict_helper(self, ["sub_gate", "qid_shape", "subspaces"])

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
@@ -378,7 +378,7 @@ def test_qubit_subspace_gate_protocols(
     assert cirq.equal_up_to_global_phase(gate, gate)
     assert cirq.equal_up_to_global_phase(gate, same_gate)
     assert cirq.equal_up_to_global_phase(gate, similar_gate)
-    assert cirq.equal_up_to_global_phase(gate, shifted_gate)
+    assert not cirq.equal_up_to_global_phase(gate, shifted_gate)
     assert not cirq.equal_up_to_global_phase(gate, flipped_gate)
     assert not cirq.equal_up_to_global_phase(gate, larger_gate)
     assert not cirq.equal_up_to_global_phase(gate, another_gate)


### PR DESCRIPTION
currently `equal_up_to_global_phase` checks if the `sub_gate` s of two `QubitSubspaceGate`s are equal \*up to global phase\*, but this isn't correct because the global phase of the sub gates because physical when expanded to higher dimensions

this pr changes `QubitSubspaceGate._equal_up_to_global_phase_` to instead use the absolute comparison of the two sub gates