### PR TITLE
allow ibmq_compile to succeed if the server doesn't send back pulses

### DIFF
--- a/cirq-superstaq/cirq_superstaq/compiler_output.py
+++ b/cirq-superstaq/cirq_superstaq/compiler_output.py
@@ -124,21 +124,22 @@ def read_json_ibmq(json_dict: Dict[str, Any], circuits_is_list: bool) -> Compile
     )
     pulses = None
 
-    if importlib.util.find_spec("qiskit"):
-        import qiskit
+    if "pulses" in json_dict:
+        if importlib.util.find_spec("qiskit"):
+            import qiskit
 
-        if "0.23" < qiskit.__version__ < "0.24":
-            pulses = gss.serialization.deserialize(json_dict["pulses"])
+            if "0.23" < qiskit.__version__ < "0.24":
+                pulses = gss.serialization.deserialize(json_dict["pulses"])
+            else:
+                warnings.warn(
+                    "ibmq_compile requires Qiskit Terra version 0.23.* to deserialize compiled "
+                    f"pulse sequences (you have {qiskit.__version__})."
+                )
         else:
             warnings.warn(
-                "ibmq_compile requires Qiskit Terra version 0.22.* to deserialize compiled pulse "
-                f"sequences (you have {qiskit.__version__})."
+                "ibmq_compile requires Qiskit Terra version 0.23.* to deserialize compiled pulse "
+                "sequences."
             )
-    else:
-        warnings.warn(
-            "ibmq_compile requires Qiskit Terra version 0.22.* to deserialize compiled pulse "
-            "sequences."
-        )
 
     if circuits_is_list:
         return CompilerOutput(compiled_circuits, final_logical_to_physicals, pulse_sequences=pulses)

--- a/cirq-superstaq/cirq_superstaq/compiler_output_test.py
+++ b/cirq-superstaq/cirq_superstaq/compiler_output_test.py
@@ -133,6 +133,14 @@ def test_read_json_ibmq() -> None:
         assert out.circuits == [circuit]
         assert out.pulse_sequences is None
 
+    json_dict.pop("pulses")
+
+    out = css.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)
+    assert out.pulse_sequence is None
+
+    out = css.compiler_output.read_json_ibmq(json_dict, circuits_is_list=True)
+    assert out.pulse_sequences is None
+
 
 @mock.patch.dict("sys.modules", {"qtrl": None})
 def test_read_json_aqt() -> None:

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -344,14 +344,20 @@ class SuperstaQProvider(
         compiled_circuits = qss.serialization.deserialize_circuits(json_dict["qiskit_circuits"])
         for circuit, metadata in zip(compiled_circuits, metadata_of_circuits):
             circuit.metadata = metadata
-        pulses = gss.serialization.deserialize(json_dict["pulses"])
+
+        pulses = None
+
+        if "pulses" in json_dict:
+            pulses = gss.serialization.deserialize(json_dict["pulses"])
+
         final_logical_to_physicals: List[Dict[int, int]] = list(
             map(dict, json.loads(json_dict["final_logical_to_physicals"]))
         )
 
         if isinstance(circuits, qiskit.QuantumCircuit):
+            pulse_sequence = None if pulses is None else pulses[0]
             return qss.compiler_output.CompilerOutput(
-                compiled_circuits[0], final_logical_to_physicals[0], pulse_sequences=pulses[0]
+                compiled_circuits[0], final_logical_to_physicals[0], pulse_sequences=pulse_sequence
             )
         return qss.compiler_output.CompilerOutput(
             compiled_circuits,

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider_test.py
@@ -216,6 +216,15 @@ def test_service_ibmq_compile(mock_ibmq_compile: MagicMock) -> None:
         [qc], [final_logical_to_physical], pulse_sequences=[mock.DEFAULT]
     )
 
+    mock_ibmq_compile.return_value.pop("pulses")
+
+    assert provider.ibmq_compile(
+        qiskit.QuantumCircuit(), test_options="yes"
+    ) == qss.compiler_output.CompilerOutput(qc, final_logical_to_physical, pulse_sequences=None)
+    assert provider.ibmq_compile([qiskit.QuantumCircuit()]) == qss.compiler_output.CompilerOutput(
+        [qc], [final_logical_to_physical], pulse_sequences=None
+    )
+
 
 def test_invalid_target_service_ibmq_compile() -> None:
     provider = qss.SuperstaQProvider(api_key="MY_TOKEN")


### PR DESCRIPTION
allows users to get compiled circuits for open qasm/non-pulse-enabled backends