### PR TITLE
clean up status handling in `css.Job`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/job.py
+++ b/cirq-superstaq/cirq_superstaq/job.py
@@ -150,7 +150,7 @@ class Job:
             collections.Counter that represents the results of the measurements
 
         Raises:
-            SuperstaQUnsuccessfulJobException: If the job has failed, been canceled, or deleted.
+            SuperstaQUnsuccessfulJobException: If the job failed or has been canceled or deleted.
             SuperstaQException: If unable to get the results from the API.
             TimeoutError: If no results are available in the provided timeout interval.
         """

--- a/cirq-superstaq/cirq_superstaq/job.py
+++ b/cirq-superstaq/cirq_superstaq/job.py
@@ -74,8 +74,8 @@ class Job:
             self._job = self._client.get_job(self.job_id())
 
     def _check_if_unsuccessful(self) -> None:
-        if self.status() in self.UNSUCCESSFUL_STATES:
-            status = self.status()
+        status = self.status()
+        if status in self.UNSUCCESSFUL_STATES:
             if "failure" in self._job and "error" in self._job["failure"]:
                 # if possible append a message to the failure status, e.g. "Failed (<message>)"
                 error = self._job["failure"]["error"]

--- a/cirq-superstaq/cirq_superstaq/job.py
+++ b/cirq-superstaq/cirq_superstaq/job.py
@@ -75,9 +75,12 @@ class Job:
 
     def _check_if_unsuccessful(self) -> None:
         if self.status() in self.UNSUCCESSFUL_STATES:
-            raise gss.superstaq_exceptions.SuperstaQUnsuccessfulJobException(
-                self.job_id(), self.status()
-            )
+            status = self.status()
+            if "failure" in self._job and "error" in self._job["failure"]:
+                # if possible append a message to the failure status, e.g. "Failed (<message>)"
+                error = self._job["failure"]["error"]
+                status += f" ({error})"
+            raise gss.SuperstaQUnsuccessfulJobException(self._job_id, status)
 
     def job_id(self) -> str:
         """Returns the job id (UID) for the job.
@@ -136,9 +139,7 @@ class Job:
         self._check_if_unsuccessful()
         return self._job["shots"]
 
-    def counts(  # pylint: disable=missing-raises-doc
-        self, timeout_seconds: int = 7200, polling_seconds: float = 1.0
-    ) -> Dict[str, int]:
+    def counts(self, timeout_seconds: int = 7200, polling_seconds: float = 1.0) -> Dict[str, int]:
         """Polls the SuperstaQ API for results.
 
         Args:
@@ -151,23 +152,19 @@ class Job:
         Raises:
             SuperstaQUnsuccessfulJobException: If the job has failed, been canceled, or deleted.
             SuperstaQException: If unable to get the results from the API.
+            TimeoutError: If no results are available in the provided timeout interval.
         """
         time_waited_seconds: float = 0.0
-        while time_waited_seconds < timeout_seconds:
+        while self.status() not in self.TERMINAL_STATES:
             # Status does a refresh.
-            if self.status() in self.TERMINAL_STATES:
-                break
+            if time_waited_seconds > timeout_seconds:
+                raise TimeoutError(
+                    f"Timed out while waiting for results. Final status was {self.status()}"
+                )
             time.sleep(polling_seconds)
             time_waited_seconds += polling_seconds
 
-        if self.status() != "Done":
-            status = self.status()
-            if "failure" in self._job and "error" in self._job["failure"]:
-                # if possible append a message to the failure status, e.g. "Failed (<message>)"
-                error = self._job["failure"]["error"]
-                status += f" ({error})"
-            raise gss.SuperstaQUnsuccessfulJobException(self._job_id, status)
-
+        self._check_if_unsuccessful()
         return self._job["samples"]
 
     def __str__(self) -> str:

--- a/cirq-superstaq/cirq_superstaq/job_test.py
+++ b/cirq-superstaq/cirq_superstaq/job_test.py
@@ -159,20 +159,21 @@ def test_job_counts_poll(mock_sleep: mock.MagicMock, job: css.job.Job) -> None:
 
 
 @mock.patch("time.sleep", return_value=None)
-def test_job_counts_poll_timeout(mock_sleep: mock.MagicMock, job: css.job.Job) -> None:
+@mock.patch("time.time", side_effect=range(20))
+def test_job_counts_poll_timeout(
+    mock_time: mock.MagicMock, mock_sleep: mock.MagicMock, job: css.job.Job
+) -> None:
     ready_job = {
         "status": "Ready",
     }
     with mocked_get_job_requests(*[ready_job] * 20):
-        with pytest.raises(gss.SuperstaQUnsuccessfulJobException, match="Ready"):
+        with pytest.raises(TimeoutError, match="Ready"):
             _ = job.counts(timeout_seconds=1, polling_seconds=0.1)
     assert mock_sleep.call_count == 11
 
 
 @mock.patch("time.sleep", return_value=None)
-def test_job_results_poll_failure(
-    mock_sleep: mock.MagicMock, job: css.job.Job
-) -> None:
+def test_job_results_poll_failure(mock_sleep: mock.MagicMock, job: css.job.Job) -> None:
     running_job = {
         "status": "Running",
     }

--- a/general-superstaq/general_superstaq/superstaq_exceptions.py
+++ b/general-superstaq/general_superstaq/superstaq_exceptions.py
@@ -41,5 +41,5 @@ class SuperstaQUnsuccessfulJobException(SuperstaQException):
     this job is attempted to be accessed.
     """
 
-    def __init__(self, job_id: str, status: str):
-        super().__init__(f"Job {job_id} was {status}.")
+    def __init__(self, job_id: str, status: str) -> None:
+        super().__init__(f"Job {job_id} terminated with status {status}.")

--- a/general-superstaq/general_superstaq/superstaq_exceptions_test.py
+++ b/general-superstaq/general_superstaq/superstaq_exceptions_test.py
@@ -37,6 +37,6 @@ def test_superstaq_not_found_exception() -> None:
 
 def test_superstaq_unsuccessful_job_exception() -> None:
     ex = gss.SuperstaQUnsuccessfulJobException(job_id="SWE", status="canceled")
-    assert str(ex) == "Status code: None, Message: 'Job SWE was canceled.'"
+    assert str(ex) == "Status code: None, Message: 'Job SWE terminated with status canceled.'"
     assert ex.status_code is None
-    assert ex.message == "Job SWE was canceled."
+    assert ex.message == "Job SWE terminated with status canceled."


### PR DESCRIPTION
* consistent use of `gss.SuperstaqUnsuccessfulJobException` for failed jobs
* improve the error message in said exception
* raise TImeoutError if `job.counts()` times out but the job hasn't failed
* fix mocked statuses in css.job_test which previously weren't any of those in Job.ALL_STATES (in one case causing a test to pass which shouldn't have)