### PR TITLE
support custom gate defs in qss

### DIFF
--- a/qiskit-superstaq/qiskit_superstaq/serialization.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization.py
@@ -17,7 +17,7 @@ T = TypeVar("T")
 RealArray = Union[int, float, List["RealArray"]]
 
 
-def json_converter(val: object) -> Dict[str, Union[str, RealArray]]:
+def json_encoder(val: object) -> Dict[str, Union[str, RealArray]]:
     """Convert (real or complex) arrays to a JSON-serializable format.
 
     Args:
@@ -40,7 +40,7 @@ def json_converter(val: object) -> Dict[str, Union[str, RealArray]]:
 
 
 def json_resolver(val: T) -> Union[T, npt.NDArray[np.complex_]]:
-    """Hook to deserialize objects that were serialized via `json_converter()`.
+    """Hook to deserialize objects that were serialized via `json_encoder()`.
 
     Args:
         val: The deserialized object.
@@ -65,7 +65,7 @@ def to_json(val: object) -> str:
     Returns:
         The JSON-serialized value (a string).
     """
-    return json.dumps(val, default=json_converter)
+    return json.dumps(val, default=json_encoder)
 
 
 def _assign_unique_inst_names(circuit: qiskit.QuantumCircuit) -> qiskit.QuantumCircuit:

--- a/qiskit-superstaq/qiskit_superstaq/serialization.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization.py
@@ -4,11 +4,32 @@ import warnings
 from typing import Dict, List, Set, Tuple, Union
 
 import general_superstaq as gss
+import numpy as np
+import numpy.typing as npt
 import qiskit
 import qiskit.qpy
 from qiskit.converters.ast_to_dag import AstInterpreter
 
 import qiskit_superstaq as qss
+
+
+def jsonified_array(name: str, array: npt.ArrayLike) -> Dict[str, Union[str, List[List[float]]]]:
+    """Convert a (real or complex) array to a JSON-serializable format.
+
+    Args:
+        name: A name to associate with the serialized array.
+        array: The array to be serialized.
+
+    Returns:
+        A JSON dictionary containing the provided name and array values.
+    """
+    array = np.asarray(array)
+    return {
+        "type": "qiskit_array",
+        "real": array.real.tolist(),
+        "imag": array.imag.tolist(),
+        "name": name,
+    }
 
 
 def _assign_unique_inst_names(circuit: qiskit.QuantumCircuit) -> qiskit.QuantumCircuit:

--- a/qiskit-superstaq/qiskit_superstaq/serialization.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization.py
@@ -13,8 +13,11 @@ from qiskit.converters.ast_to_dag import AstInterpreter
 
 import qiskit_superstaq as qss
 
+T = TypeVar("T")
+RealArray = Union[int, float, List["RealArray"]]
 
-def json_converter(val: object) -> Dict[str, Union[str, List[List[float]]]]:
+
+def json_converter(val: object) -> Dict[str, Union[str, RealArray]]:
     """Convert (real or complex) arrays to a JSON-serializable format.
 
     Args:
@@ -34,9 +37,6 @@ def json_converter(val: object) -> Dict[str, Union[str, List[List[float]]]]:
         }
 
     raise TypeError(f"Object of type {type(val)} is not JSON serializable.")
-
-
-T = TypeVar("T")
 
 
 def json_resolver(val: T) -> Union[T, npt.NDArray[np.complex_]]:

--- a/qiskit-superstaq/qiskit_superstaq/serialization_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization_test.py
@@ -11,6 +11,25 @@ import qiskit
 import qiskit_superstaq as qss
 
 
+def test_jsonified_array() -> None:
+    real_part = np.random.uniform(-1, 1, size=(4, 4))
+    imag_part = np.random.uniform(-1, 1, size=(4, 4))
+
+    assert qss.serialization.jsonified_array("random_real", real_part) == {
+        "type": "qiskit_array",
+        "real": real_part.tolist(),
+        "imag": 4 * [[0, 0, 0, 0]],
+        "name": "random_real",
+    }
+
+    assert qss.serialization.jsonified_array("random_complex", real_part + 1j * imag_part) == {
+        "type": "qiskit_array",
+        "real": real_part.tolist(),
+        "imag": imag_part.tolist(),
+        "name": "random_complex",
+    }
+
+
 def test_assign_unique_inst_names() -> None:
     inst_0 = qss.ZZSwapGate(0.1)
     inst_1 = qss.ZZSwapGate(0.2)

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_backend.py
@@ -190,7 +190,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
         return {
             "qiskit_circuits": serialized_circuits,
             "target": self.name(),
-            "options": json.dumps(kwargs),
+            "options": qss.serialization.to_json(kwargs),
         }
 
     def aqt_compile(
@@ -242,13 +242,8 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
             options["random_seed"] = random_seed
         if atol is not None:
             options["atol"] = atol
-
         if gate_defs is not None:
-            json_gate_defs = {}
-            for key, val in gate_defs.items():
-                val = np.asarray(val)
-                json_gate_defs[key] = qss.serialization.jsonified_array(key, val)
-            options["gate_defs"] = json_gate_defs
+            options["gate_defs"] = gate_defs
 
         metadata_of_circuits = _get_metadata_of_circuits(circuits)
         circuits_is_list = not isinstance(circuits, qiskit.QuantumCircuit)

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_backend.py
@@ -14,9 +14,11 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 import general_superstaq as gss
+import numpy as np
+import numpy.typing as npt
 import qiskit
 
 import qiskit_superstaq as qss
@@ -108,11 +110,14 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
         Returns:
             A Superstaq job storing ID and other related info.
-        """
 
+        Raises:
+            ValueError: If `circuits` contains invalid circuits for submission.
+        """
         if isinstance(circuits, qiskit.QuantumCircuit):
             circuits = [circuits]
 
+        qss.validation.validate_qiskit_circuits(circuits)
         if not all(circuit.count_ops().get("measure") for circuit in circuits):
             # TODO: only raise if the run method actually requires samples (and not for e.g. a
             # statevector simulation)
@@ -194,6 +199,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
         num_equivalent_circuits: Optional[int] = None,
         random_seed: Optional[int] = None,
         atol: Optional[float] = None,
+        gate_defs: Optional[Mapping[str, Union[str, npt.NDArray[np.complex_], None]]] = None,
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
         """Compiles and optimizes the given circuit(s) for the Advanced Quantum Testbed (AQT) at
@@ -208,6 +214,12 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
             random_seed: Optional seed used for approximate synthesis and ECA.
             atol: Optional tolerance to use for approximate gate synthesis (currently just for
                 qutrit gates).
+            gate_defs: An optional dictionary mapping names in qtrl configs to operations, where
+                each operation can be either a unitary matrix or None. More specific associations
+                take precedence, for example `{"SWAP": <matrix1>, "SWAP/C5C4": <matrix2>}` implies
+                `<matrix1>` for all "SWAP" calibrations except "SWAP/C5C4" (which will instead be
+                mapped to `<matrix2>` applied to qubits 4 and 5). Setting any calibration to None
+                will disable that calibration.
             kwargs: Other desired compile options.
 
         Returns:
@@ -230,6 +242,13 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
             options["random_seed"] = random_seed
         if atol is not None:
             options["atol"] = atol
+
+        if gate_defs is not None:
+            json_gate_defs = {}
+            for key, val in gate_defs.items():
+                val = np.asarray(val)
+                json_gate_defs[key] = qss.serialization.jsonified_array(key, val)
+            options["gate_defs"] = json_gate_defs
 
         metadata_of_circuits = _get_metadata_of_circuits(circuits)
         circuits_is_list = not isinstance(circuits, qiskit.QuantumCircuit)

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_backend_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_backend_test.py
@@ -152,9 +152,7 @@ def test_aqt_compile(mock_post: MagicMock) -> None:
         json={
             "qiskit_circuits": qss.serialize_circuits([qc, qc]),
             "target": "aqt_keysight_qpu",
-            "options": json.dumps(
-                {"gate_defs": {"CRX": qss.serialization.jsonified_array("CRX", matrix)}}
-            ),
+            "options": qss.serialization.to_json({"gate_defs": {"CRX": matrix}}),
         },
     )
 

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_backend_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_backend_test.py
@@ -108,11 +108,31 @@ def test_aqt_compile(mock_post: MagicMock) -> None:
     assert out.circuit == qc
     assert out.final_logical_to_physical == {1: 4}
     assert not hasattr(out, "circuits") and not hasattr(out, "pulse_lists")
+    mock_post.assert_called_with(
+        f"{provider._client.url}/aqt_compile",
+        headers=provider._client.headers,
+        verify=provider._client.verify_https,
+        json={
+            "qiskit_circuits": qss.serialize_circuits(qc),
+            "target": "aqt_keysight_qpu",
+            "options": "{}",
+        },
+    )
 
     out = backend.compile([qc], atol=1e-2)
     assert out.circuits == [qc]
     assert out.final_logical_to_physicals == [{1: 4}]
     assert not hasattr(out, "circuit") and not hasattr(out, "pulse_list")
+    mock_post.assert_called_with(
+        f"{provider._client.url}/aqt_compile",
+        headers=provider._client.headers,
+        verify=provider._client.verify_https,
+        json={
+            "qiskit_circuits": qss.serialize_circuits(qc),
+            "target": "aqt_keysight_qpu",
+            "options": json.dumps({"atol": 1e-2}),
+        },
+    )
 
     mock_post.return_value.json = lambda: {
         "qiskit_circuits": qss.serialization.serialize_circuits([qc, qc]),
@@ -120,10 +140,23 @@ def test_aqt_compile(mock_post: MagicMock) -> None:
         "state_jp": gss.serialization.serialize({}),
         "pulse_lists_jp": gss.serialization.serialize([[[]], [[]]]),
     }
-    out = backend.compile([qc, qc], test_options="yes")
+    matrix = qiskit.circuit.library.CRXGate(1.23).to_matrix()
+    out = backend.compile([qc, qc], gate_defs={"CRX": matrix})
     assert out.circuits == [qc, qc]
     assert out.final_logical_to_physicals == [{}, {}]
     assert not hasattr(out, "circuit") and not hasattr(out, "pulse_list")
+    mock_post.assert_called_with(
+        f"{provider._client.url}/aqt_compile",
+        headers=provider._client.headers,
+        verify=provider._client.verify_https,
+        json={
+            "qiskit_circuits": qss.serialize_circuits([qc, qc]),
+            "target": "aqt_keysight_qpu",
+            "options": json.dumps(
+                {"gate_defs": {"CRX": qss.serialization.jsonified_array("CRX", matrix)}}
+            ),
+        },
+    )
 
     with pytest.raises(ValueError, match="aqt_keysight_qpu is not a valid IBMQ target."):
         backend.ibmq_compile([qc])

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import general_superstaq as gss
 import numpy as np
@@ -154,6 +154,7 @@ class SuperstaQProvider(
         circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
         target: str = "aqt_keysight_qpu",
         atol: Optional[float] = None,
+        gate_defs: Optional[Mapping[str, Union[str, npt.NDArray[np.complex_], None]]] = None,
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
         """Compiles and optimizes the given circuit(s) for the Advanced Quantum Testbed (AQT) at
@@ -163,6 +164,12 @@ class SuperstaQProvider(
             circuits: The circuit(s) to compile.
             target: A string containing the name of a target AQT backend.
             atol: An optional tolerance to use for approximate gate synthesis.
+            gate_defs: An optional dictionary mapping names in qtrl configs to operations, where
+                each operation can be either a unitary matrix or None. More specific associations
+                take precedence, for example `{"SWAP": <matrix1>, "SWAP/C5C4": <matrix2>}` implies
+                `<matrix1>` for all "SWAP" calibrations except "SWAP/C5C4" (which will instead be
+                mapped to `<matrix2>` applied to qubits 4 and 5). Setting any calibration to None
+                will disable that calibration.
             kwargs: Other desired aqt_compile options.
 
         Returns:
@@ -177,7 +184,7 @@ class SuperstaQProvider(
         if not target.startswith("aqt_"):
             raise ValueError(f"{target} is not an AQT target")
 
-        return self.get_backend(target).compile(circuits, atol=atol, **kwargs)
+        return self.get_backend(target).compile(circuits, atol=atol, gate_defs=gate_defs, **kwargs)
 
     def aqt_compile_eca(
         self,
@@ -186,6 +193,7 @@ class SuperstaQProvider(
         random_seed: Optional[int] = None,
         target: str = "aqt_keysight_qpu",
         atol: Optional[float] = None,
+        gate_defs: Optional[Mapping[str, Union[str, npt.NDArray[np.complex_], None]]] = None,
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
         """Compiles and optimizes the given circuit(s) for the Advanced Quantum Testbed (AQT) at
@@ -200,6 +208,12 @@ class SuperstaQProvider(
             random_seed: Optional seed for circuit randomizer.
             target: A string containing the name of a target AQT backend.
             atol: An optional tolerance to use for approximate gate synthesis.
+            gate_defs: An optional dictionary mapping names in qtrl configs to operations, where
+                each operation can be either a unitary matrix or None. More specific associations
+                take precedence, for example `{"SWAP": <matrix1>, "SWAP/C5C4": <matrix2>}` implies
+                `<matrix1>` for all "SWAP" calibrations except "SWAP/C5C4" (which will instead be
+                mapped to `<matrix2>` applied to qubits 4 and 5). Setting any calibration to None
+                will disable that calibration.
             kwargs: Other desired aqt_compile_eca options.
 
         Returns:
@@ -218,7 +232,8 @@ class SuperstaQProvider(
             circuits,
             num_equivalent_circuits=num_equivalent_circuits,
             random_seed=random_seed,
-            atorl=atol,
+            atol=atol,
+            gate_defs=gate_defs,
             **kwargs,
         )
 


### PR DESCRIPTION
(mostly just adds a custom converter/resolver to qss.serialization because numpy arrays aren't json-serializable)

confirmed this works locally after the corresponding server-side changes

part of #502